### PR TITLE
 ADX-1042 Separate management auth0 domain for auth0 api calls.

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,6 +9,7 @@ class Config(object):
     LANGUAGES = os.getenv('PROFILE_EDITOR_LANGUAGES', 'en,fr,pt_PT').split(',')
     DEFAULT_LANGUAGE = os.getenv('PROFILE_EDITOR_DEFAULT_LANGUAGE', 'en')
     AUTH0_DOMAIN = os.getenv('AUTH0_DOMAIN')
+    AUTH0_MANAGEMENT_DOMAIN = os.getenv('AUTH0_MANAGEMENT_DOMAIN')
     AUTH0_CLIENT_ID = os.getenv('AUTH0_CLIENT_ID')
     AUTH0_CLIENT_SECRET = os.getenv('AUTH0_CLIENT_SECRET')
     APP_SECRET_KEY = os.getenv('APP_SECRET_KEY')
@@ -17,6 +18,7 @@ class Config(object):
 class Testing(Config):
     TESTING = True
     AUTH0_DOMAIN = 'fake-auth0-domain'
+    AUTH0_MANAGEMENT_DOMAIN = 'fake-auth0-domain'
     AUTH0_CLIENT_ID = 'client_id'
     AUTH0_CLIENT_SECRET = 'client_secret'
     APP_SECRET_KEY = '1234567890abcdef'

--- a/profile_editor/logic.py
+++ b/profile_editor/logic.py
@@ -84,7 +84,7 @@ def execute_mgmt_api_request(method, url, data_object=None):
         'Authorization': f'Bearer {mgmt_token}',
         'Content-Type': 'application/json'
     }
-    auth0_domain = current_app.config["AUTH0_DOMAIN"]
+    auth0_domain = current_app.config["AUTH0_MANAGEMENT_DOMAIN"]
     data = json.dumps(data_object) if data_object else None
     url = f'https://{auth0_domain}{url}'
     result = requests.request(method=method,

--- a/profile_editor/logic.py
+++ b/profile_editor/logic.py
@@ -33,7 +33,7 @@ def get_session():
 def get_mgmt_token():
     client_id = current_app.config['AUTH0_CLIENT_ID']
     client_secret = current_app.config['AUTH0_CLIENT_SECRET']
-    auth0_domain = current_app.config["AUTH0_DOMAIN"]
+    auth0_domain = current_app.config["AUTH0_MANAGEMENT_DOMAIN"]
     payload = f"grant_type=client_credentials&client_id={client_id}" \
               f"&client_secret={client_secret}" \
               f"&audience=https://{auth0_domain}/api/v2/"


### PR DESCRIPTION
## Description

Our auth0 account for HIV Tools is using a custom domain. It turns out that you can’t access auth0 managment API via a custom domain. That’s why a change in configuration is needed to use different auth0 domain for profile editor frontend and backend.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
