### PR TITLE
ADX-1041 Support for custom flash messages passed from ADR

### DIFF
--- a/profile_editor/routes.py
+++ b/profile_editor/routes.py
@@ -59,7 +59,7 @@ def profile():
     back_url = session.get("back_url") if session.get("back_url", "") else None
     after_save_url = session.get("after_save_url") \
         if session.get("after_save_url", "") else None
-    flash_message = session.pop("flash_message")
+    flash_message = session.pop("flash_message", None)
     if flash_message:
         flash(flash_message)
     success = request.args.get("success", False)

--- a/profile_editor/routes.py
+++ b/profile_editor/routes.py
@@ -22,6 +22,7 @@ def home():
         session["lang"] = lang
     set_or_clear_session_variable("back_url")
     set_or_clear_session_variable("after_save_url")
+    set_or_clear_session_variable("flash_message")
 
     if session.get("user_id", ""):
         return redirect("/profile")
@@ -58,6 +59,9 @@ def profile():
     back_url = session.get("back_url") if session.get("back_url", "") else None
     after_save_url = session.get("after_save_url") \
         if session.get("after_save_url", "") else None
+    flash_message = session.pop("flash_message")
+    if flash_message:
+        flash(flash_message)
     success = request.args.get("success", False)
 
     return render_template(

--- a/profile_editor/routes.py
+++ b/profile_editor/routes.py
@@ -51,19 +51,21 @@ def profile():
     if form.validate_on_submit():
         logic.update_user_data(form, user_id)
         flash(_('User profile successfully saved'))
-        return redirect(url_for("main.profile"))
+        return redirect(url_for("main.profile", success=True))
     elif not form.is_submitted():
         form = logic.load_data_from_server_to_form(form, user_id)
 
     back_url = session.get("back_url") if session.get("back_url", "") else None
     after_save_url = session.get("after_save_url") \
         if session.get("after_save_url", "") else None
+    success = request.args.get("success", False)
 
     return render_template(
         "profile.html",
         form=form,
         back_url=back_url,
-        after_save_url=after_save_url
+        after_save_url=after_save_url,
+        success=success
     )
 
 

--- a/templates/snippets/form.html
+++ b/templates/snippets/form.html
@@ -55,7 +55,7 @@
                                                             {% for message in messages %}
                                                                 <li>{{ message }}</li>
                                                             {% endfor %}
-                                                                {% if after_save_url %}
+                                                                {% if success %}
                                                                     <br/>
                                                                     <li>
                                                                         {{ _('You will be redirected to your original page in') }} <span


### PR DESCRIPTION
## Description

1. Fixed a bug where success flash message and return to after_save_url happened if any flash messages present
2. Added support for passing a custom flash message on initial request by url arg `flash_message`.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
